### PR TITLE
Merge PullRequestEvent and PushEvent

### DIFF
--- a/js/bend/background.js
+++ b/js/bend/background.js
@@ -130,6 +130,10 @@ var spk = spk || {};
                             mergedEventsQuantity = spk.events.custom.issuesEvents.check(events, i, currentEvent);
                         }
 
+                        if (!mergedEventsQuantity) {
+                            mergedEventsQuantity = spk.events.custom.pullRequestsEvents.check(events, i, currentEvent);
+                        }
+
                         if (mergedEventsQuantity) {
                             decrement = mergedEventsQuantity;
                         }

--- a/js/bend/events/custom/custom_events.js
+++ b/js/bend/events/custom/custom_events.js
@@ -1,0 +1,21 @@
+/**
+ * Created by Nahuel Barrios on 11/02/16.
+ */
+/**
+ * Created by Nahuel Barrios on 11/02/16.
+ */
+var spk = spk || {};
+spk.events = spk.events || {};
+spk.events.custom = spk.events.custom || {};
+
+spk.events.custom.isSameIssue = function (currentEvent, nextEvent) {
+    return nextEvent.type === 'IssuesEvent' && nextEvent.payload.issue.number == currentEvent.payload.issue.number;
+};
+
+spk.events.custom.isSamePullRequest = function (currentEvent, nextEvent) {
+    return nextEvent.type === 'PullRequestEvent' && nextEvent.payload.pull_request.number == currentEvent.payload.issue.number;
+};
+
+spk.events.custom.isSameActor = function (currentEvent, nextEvent) {
+    return currentEvent.actor.login === nextEvent.actor.login;
+};

--- a/js/bend/events/custom/custom_issues_events.js
+++ b/js/bend/events/custom/custom_issues_events.js
@@ -10,17 +10,9 @@ spk.events.custom.issuesEvents = (function () {
     var check = function (events, index, currentEvent) {
         var decrement;
 
-        function isSameIssue(currentEvent, nextEvent) {
-            return nextEvent.type === 'IssuesEvent' && nextEvent.payload.issue.number == currentEvent.payload.issue.number
-        }
-
-        function isSamePullRequest(currentEvent, nextEvent) {
-            return nextEvent.type === 'PullRequestEvent' && nextEvent.payload.pull_request.number == currentEvent.payload.issue.number
-        }
-
         if (currentEvent.type === 'IssueCommentEvent' && index - 1 >= 0) {
             var nextEvent = events[index - 1];
-            if ((isSameIssue(currentEvent, nextEvent) || isSamePullRequest(currentEvent, nextEvent))
+            if ((spk.events.custom.isSameIssue(currentEvent, nextEvent) || spk.events.custom.isSamePullRequest(currentEvent, nextEvent))
                 && (nextEvent.payload.action === 'closed' || nextEvent.payload.action === 'reopened')) {
 
                 currentEvent.type += '+' + nextEvent.type;

--- a/js/bend/events/custom/custom_pull_requests_events.js
+++ b/js/bend/events/custom/custom_pull_requests_events.js
@@ -1,0 +1,47 @@
+/**
+ * Created by Nahuel Barrios on 11/02/16.
+ */
+var spk = spk || {};
+spk.events = spk.events || {};
+spk.events.custom = spk.events.custom || {};
+
+spk.events.custom.pullRequestsEvents = (function () {
+
+    var check = function (events, index, currentEvent) {
+        var decrement;
+
+        var containsSameLatestCommit = function (pullRequestEvent, pushEvent) {
+            var commitShaFromPullRequestEvent = pullRequestEvent.payload.pull_request.head.sha;
+            var commitShaFromPushEvent = pushEvent.payload.commits[pushEvent.payload.commits.length - 2].sha;
+
+            return commitShaFromPullRequestEvent === commitShaFromPushEvent;
+        };
+
+        var isPullRequestClosedAndMerged = function (currentEvent) {
+            return currentEvent.payload.action === 'closed' && currentEvent.payload.pull_request.merged;
+        };
+
+        var isPushToTheSameBranch = function (currentEvent, nextEvent) {
+            return currentEvent.payload.pull_request.base.ref === nextEvent.payload.ref.substring(nextEvent.payload.ref.lastIndexOf('/') + 1)
+        };
+
+        if (currentEvent.type === 'PullRequestEvent' && index - 1 >= 0) {
+            var nextEvent = events[index - 1];
+            if (isPullRequestClosedAndMerged(currentEvent)
+                && spk.events.custom.isSameActor(currentEvent, nextEvent)
+                && isPushToTheSameBranch(currentEvent, nextEvent)
+                && containsSameLatestCommit(currentEvent, nextEvent)) {
+
+                // The only action we take here is skipping nextEvent (PushEvent) because the user knows that merging a PR implies pushing to that branch.
+
+                decrement = 2;
+            }
+        }
+
+        return decrement;
+    };
+
+    return {
+        check: check
+    };
+}());

--- a/js/bend/events/pull_request_event.js
+++ b/js/bend/events/pull_request_event.js
@@ -16,6 +16,7 @@ spk.events.pullRequestEvent = (function () {
             , deletions: event.payload.pull_request.deletions
             , author: '@' + event.payload.pull_request.user.login
             , link: event.payload.pull_request.html_url
+            , targetBranch: event.payload.pull_request.base.ref
         };
     };
 
@@ -39,6 +40,10 @@ spk.events.pullRequestEvent = (function () {
                 console.warn('Wow! We\'ve got a new PR action and it is NOT mapped a switch statement.');
                 icon = undefined;
                 break;
+        }
+
+        if (action === 'merged') {
+            action += ' into branch "' + dto.payload.targetBranch + '"';
         }
 
         return {

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,9 @@
             "js/bend/events/release_event.js",
             "js/bend/events/watch_event.js",
             "js/bend/events/manager.js",
+            "js/bend/events/custom/custom_events.js",
             "js/bend/events/custom/custom_issues_events.js",
+            "js/bend/events/custom/custom_pull_requests_events.js",
             "js/bend/api/lib.js",
             "js/bend/background.js"
         ],


### PR DESCRIPTION
We're just skipping the PushEvent because the user knows that merging a PR implies pushing to that branch.
- closes #4 
