### PR TITLE
Fix starred repos click event

### DIFF
--- a/extension/js/bend/api/lib.js
+++ b/extension/js/bend/api/lib.js
@@ -6,16 +6,16 @@ spk.lib = (function () {
 
     var getEvents = function (callback) {
 
-        chrome.storage.sync.get('username', function (localStorage) {
-            if (localStorage.username) {
+        chrome.storage.sync.get('username', function (syncedStorage) {
+            if (syncedStorage.username) {
 
-                chrome.storage.local.get('accessToken', function (syncedStorage) {
+                chrome.storage.local.get('accessToken', function (localStorage) {
 
-                    if (syncedStorage.accessToken) {
+                    if (localStorage.accessToken) {
                         $.ajax({
-                            url: 'https://api.github.com/users/' + localStorage.username + '/received_events',
+                            url: 'https://api.github.com/users/' + syncedStorage.username + '/received_events',
                             beforeSend: function (jqXHR) {
-                                jqXHR.setRequestHeader('Authorization', 'token ' + syncedStorage.accessToken);
+                                jqXHR.setRequestHeader('Authorization', 'token ' + localStorage.accessToken);
                             }
                         }).done(function (data, textStatus, jqXHR) {
                             console.info('GitHub\'s API called OK');

--- a/extension/js/bend/background.js
+++ b/extension/js/bend/background.js
@@ -52,8 +52,8 @@ var spk = spk || {};
         });
     };
 
-    var processEvent = function (eachEvent) {
-        var dto = spk.events.manager.parse(eachEvent);
+    var processEvent = function (eachEvent, username) {
+        var dto = spk.events.manager.parse(eachEvent, username);
         var notification;
 
         if (dto && spk.events.manager.shouldProcess(dto)) {
@@ -209,7 +209,7 @@ var spk = spk || {};
                     for (var i = 0; i < mergedEvents.length; i++) {
                         var eachMergedEvent = mergedEvents[i];
 
-                        var notification = processEvent(eachMergedEvent);
+                        var notification = processEvent(eachMergedEvent, storage.username);
                         if (notification) {
                             notifications.push(notification);
                         }

--- a/extension/js/bend/events/create_event.js
+++ b/extension/js/bend/events/create_event.js
@@ -28,15 +28,10 @@ spk.events.createEvent = (function () {
                 };
                 break;
             case 'tag':
-                result = {
-                    branch: event.payload.ref
-                    , link: buildRepoPage(event.repo.name, 'releases', event.payload.ref)
-                };
-                break;
             case 'branch':
                 result = {
                     branch: event.payload.ref
-                    , link: buildRepoPage(event.repo.name, 'tree', event.payload.ref)
+                    , link: buildRepoPage(event.repo.name, event.payload.ref_type == 'tag' ? 'releases' : 'tree', event.payload.ref)
                 };
                 break;
             default:

--- a/extension/js/bend/events/create_event.js
+++ b/extension/js/bend/events/create_event.js
@@ -13,19 +13,19 @@ spk.events.createEvent = (function () {
             case 'repository':
                 result = {
                     description: event.payload.description
-                    , link: 'https://github.com/' + event.repo.name
+                    , link: spk.properties.github_web + event.repo.name
                 };
                 break;
             case 'tag':
                 result = {
                     branch: event.payload.ref
-                    , link: 'https://github.com/' + event.repo.name + '/releases/' + event.payload.ref
+                    , link: spk.properties.github_web + event.repo.name + '/releases/' + event.payload.ref
                 };
                 break;
             case 'branch':
                 result = {
                     branch: event.payload.ref
-                    , link: 'https://github.com/' + event.repo.name + '/tree/' + event.payload.ref
+                    , link: spk.properties.github_web + event.repo.name + '/tree/' + event.payload.ref
                 };
                 break;
             default:

--- a/extension/js/bend/events/create_event.js
+++ b/extension/js/bend/events/create_event.js
@@ -31,7 +31,7 @@ spk.events.createEvent = (function () {
             case 'branch':
                 result = {
                     branch: event.payload.ref
-                    , link: buildRepoPage(event.repo.name, event.payload.ref_type == 'tag' ? 'releases' : 'tree', event.payload.ref)
+                    , link: buildRepoPage(event.repo.name, event.payload.ref_type === 'tag' ? 'releases' : 'tree', event.payload.ref)
                 };
                 break;
             default:

--- a/extension/js/bend/events/create_event.js
+++ b/extension/js/bend/events/create_event.js
@@ -6,6 +6,17 @@ spk.events = spk.events || {};
 
 spk.events.createEvent = (function () {
 
+    /**
+     * Generates the entire web page for a specific GitHub section.
+     * @param repo It should be the repo's owner and the repo name, like: "barriosnahuel/spokesman".
+     * @param section The target section, like "releases".
+     * @param branch You know what.
+     * @returns {string} i.e.: https://github.com/barriosnahuel/spokesman/tree/develop
+     */
+    var buildRepoPage = function (repo, section, branch) {
+        return spk.properties.github_web + repo + '/' + section + '/' + branch;
+    };
+
     var parseGitHubEvent = function (event) {
         var result;
 
@@ -19,13 +30,13 @@ spk.events.createEvent = (function () {
             case 'tag':
                 result = {
                     branch: event.payload.ref
-                    , link: spk.properties.github_web + event.repo.name + '/releases/' + event.payload.ref
+                    , link: buildRepoPage(event.repo.name, 'releases', event.payload.ref)
                 };
                 break;
             case 'branch':
                 result = {
                     branch: event.payload.ref
-                    , link: spk.properties.github_web + event.repo.name + '/tree/' + event.payload.ref
+                    , link: buildRepoPage(event.repo.name, 'tree', event.payload.ref)
                 };
                 break;
             default:

--- a/extension/js/bend/events/delete_event.js
+++ b/extension/js/bend/events/delete_event.js
@@ -10,7 +10,7 @@ spk.events.deleteEvent = (function () {
         return {
             branch: event.payload.ref
             , type: event.payload.ref_type
-            , link: 'https://github.com/' + event.repo.name + (event.payload.ref_type === 'tag' ? '/tags' : '/branches')
+            , link: spk.properties.github_web + event.repo.name + (event.payload.ref_type === 'tag' ? '/tags' : '/branches')
         };
     };
 

--- a/extension/js/bend/events/manager.js
+++ b/extension/js/bend/events/manager.js
@@ -63,15 +63,16 @@ spk.events.manager = (function () {
     };
 
     /**
-     * ToDo: Add documentation!!
-     * @param event
+     * Parse basic data required for any kind of event, and also parses each specific event's data by calling the manager.js.
+     * @param event The event to parse.
+     * @param username The login name of the configured user.
      */
-    var parse = function (event) {
+    var parse = function (event, username) {
         var result;
 
         var eventManager = findEvent(event.type);
         if (eventManager) {
-            var payload = eventManager.parse(event);
+            var payload = eventManager.parse(event, username);
 
             if (payload) {
                 var dto = parseBasicData(event);

--- a/extension/js/bend/events/push_event.js
+++ b/extension/js/bend/events/push_event.js
@@ -11,7 +11,7 @@ spk.events.pushEvent = (function () {
         return {
             commitsQuantity: event.payload.size
             , branch: branch
-            , link: 'https://github.com/' + event.repo.name + '/commits/' + branch
+            , link: spk.properties.github_web + event.repo.name + '/commits/' + branch
         };
     };
 

--- a/extension/js/bend/events/watch_event.js
+++ b/extension/js/bend/events/watch_event.js
@@ -6,12 +6,20 @@ spk.events = spk.events || {};
 
 spk.events.watchEvent = (function () {
 
-    var parseGitHubEvent = function (event) {
+    var parseGitHubEvent = function (event, username) {
+        var repoOwner = event.repo.name.substring(0, event.repo.name.indexOf('/'));
+
+        var link;
+        if (repoOwner === username) {
+            link = spk.properties.github_web + event.actor.login
+        } else {
+            link = spk.properties.github_web + event.repo.name;
+        }
 
         return {
             user: event.actor.login,
             repo: event.repo.name,
-            link: 'https://github.com/' + event.actor.login
+            link: link
         };
     };
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Spokesman - GitHub's notifications",
     "short_name": "Spokesman",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Get desktop notifications of events that occur on GitHub that really interest you.",
     "browser_action": {
         "default_icon": {

--- a/extension/properties.json
+++ b/extension/properties.json
@@ -1,4 +1,6 @@
 {
+    "testing": false,
+    "github_web": "https://github.com/",
     "push_branches": [
         "master",
         "develop",


### PR DESCRIPTION
From now on, clicking on a "starred repo" event will open the repo's main page when the user is **not** the repo owner. fixes #46

I made a little refactor by externalizing github.com as a property.
